### PR TITLE
Update log message for nats connection

### DIFF
--- a/telematic_system/telematic_units/carma_street_bridge/streets_nats_bridge/src/streets_nats_bridge.py
+++ b/telematic_system/telematic_units/carma_street_bridge/streets_nats_bridge/src/streets_nats_bridge.py
@@ -177,10 +177,11 @@ class StreetsNatsBridge():
             reconnected_cb=reconnected_cb,
             disconnected_cb=disconnected_cb,
             max_reconnect_attempts=1)
+            self.logger.info(" In nats_connect: Connected to nats server!")
         except:
             self.logger.error(" In nats_connect: Error connecting to nats server")
         finally:
-            self.logger.info(" In nats_connect: Connected to nats server")
+            self.logger.info(" In nats_connect: Done nats connection call.")
        
     #Waits for request from telematic server to publish available topics. When a request has been received, it responds
     #with all available carma-streets kafka topics.


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Update log message for nats connection. When running the bridge without a Nats server up, the log message seems to show it is connected to nats service which is incorrect.
<!--- Describe your changes in detail -->

## Related Issue
NA
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Telematic Unit
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CDA Telematics Contributing Guide](https://github.com/usdot-fhwa-stol/cda-telematics/blob/main/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
