### PR TITLE
streets nats bridge print misleading message when unsubscribe topics

### DIFF
--- a/telematic_system/telematic_units/carma_street_bridge/streets_nats_bridge/src/streets_nats_bridge.py
+++ b/telematic_system/telematic_units/carma_street_bridge/streets_nats_bridge/src/streets_nats_bridge.py
@@ -315,7 +315,7 @@ class StreetsNatsBridge():
             for existing_topic in list(self.subscribers_list):
                 if (existing_topic not in requested_topics):
                     try:
-                        self.logger.info('Trying to unsubscribe from topic update: "%s"' % existing_topic)
+                        self.logger.info('Trying to unsubscribe from topic: "%s"' % existing_topic)
                         self.subscribers_list.remove(existing_topic)
                     except:
                         self.logger.error('Unable to unsubscribe from topic: "%s" '% existing_topic)


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
 " trying to unsubscribe from topic message "  Info message print out for all topics even  the topics are not to be unsubscribed.
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/cda-telematics/issues/65
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
WFD tool integration test bugs
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local integration test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CDA Telematics Contributing Guide](https://github.com/usdot-fhwa-stol/cda-telematics/blob/main/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
