### PR TITLE
Telematic UI won't allow unsubscribing from a single topic

### DIFF
--- a/telematic_system/telematic_apps/web_app/client/src/api/api-topics.js
+++ b/telematic_system/telematic_apps/web_app/client/src/api/api-topics.js
@@ -44,18 +44,18 @@ const requestSelectedLiveUnitsTopics = async (seletedUnitTopicListToConfirm) => 
                     body.topics.push(topic.name);
                 });
             });
+        }
 
-            //Send request to stream data 
-            let unitStatus = body.unit_name + " (" + body.unit_id + "): ";
-            try {
-                const { data } = await axios.post(URL, body);
-                sentStatus.push({ data: unitStatus + data });
-            } catch (err) {
-                sentStatus.push({
-                    errCode: err.response !== undefined ? err.response.status : "404",
-                    errMsg: err.response !== undefined ? unitStatus + err.response.statusText + err.response.data : unitStatus + "No reponse from server."
-                });
-            }
+        //Send request to stream data 
+        let unitStatus = body.unit_name + " (" + body.unit_id + "): ";
+        try {
+            const { data } = await axios.post(URL, body);
+            sentStatus.push({ data: unitStatus + data });
+        } catch (err) {
+            sentStatus.push({
+                errCode: err.response !== undefined ? err.response.status : "404",
+                errMsg: err.response !== undefined ? unitStatus + err.response.statusText + err.response.data : unitStatus + "No reponse from server."
+            });
         }
     }));
     return sentStatus;

--- a/telematic_system/telematic_apps/web_app/client/src/pages/TopicPage.js
+++ b/telematic_system/telematic_apps/web_app/client/src/pages/TopicPage.js
@@ -86,6 +86,18 @@ const TopicPage = React.memo(() => {
   //Send topic request to the server
   const confirmSelectedTopicHandler = () => {
     const seletedUnitTopicListToConfirm = TopicCtx.selected_unit_topics_list;
+    let isClear = false;
+    if (seletedUnitTopicListToConfirm.length === 0) {
+      isClear = true;
+      for (let vehicle of vehicles) {
+        let clearUnits = { unit_identifier: vehicle.unit_identifier, unit_name: vehicle.unit_name };
+        seletedUnitTopicListToConfirm.push(clearUnits);
+      }
+      for (let infrastructure of infrastructures) {
+        let clearUnits = { unit_identifier: infrastructure.unit_identifier, unit_name: infrastructure.unit_name };
+        seletedUnitTopicListToConfirm.push(clearUnits);
+      }
+    }
     const response_data = requestSelectedLiveUnitsTopics(seletedUnitTopicListToConfirm);
     let messageList = [];
     let num_failed = 0;
@@ -96,7 +108,7 @@ const TopicPage = React.memo(() => {
           if (item.data !== undefined) {
             messageList.push(item.data);
             num_success += 1;
-          } else if (item.errCode !== undefined) {
+          } else if (!isClear && item.errCode !== undefined) {
             messageList.push(item.errMsg);
             num_failed += 1;
           }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
When the users do not select any topics at all, they are allowed to send confirm topic request to the backend to service.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/cda-telematics/issues/67
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
data analysis
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CDA Telematics Contributing Guide](https://github.com/usdot-fhwa-stol/cda-telematics/blob/main/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
