### PR TITLE
empty subscriber list on empty sub request

### DIFF
--- a/telematic_system/telematic_units/carma_vehicle_bridge/ros2_nats_bridge/ros2_nats_bridge/api.py
+++ b/telematic_system/telematic_units/carma_vehicle_bridge/ros2_nats_bridge/ros2_nats_bridge/api.py
@@ -248,6 +248,14 @@ class Ros2NatsBridgeNode(Node):
 
             incoming_topics = [v for i, v in enumerate(
                 self.get_topic_names_and_types()) if v[0] in data["topics"]]
+            
+             # If list of topics requested is empty unsubscribe to all topics
+            if not incoming_topics:
+                for existing_topic in list(self.subscribers_list.keys()):
+                    await topic_unsubscribe_request(existing_topic)
+                # Exit function since nothing else needs to be done in this method
+                self.logger.info("Unsubscribed to all topics")
+                return
 
             # Remove topics from subscribers list that weren't called in new request
             for existing_topic in list(self.subscribers_list.keys()):
@@ -256,6 +264,8 @@ class Ros2NatsBridgeNode(Node):
                         self.logger.info('Trying to unsubscribe from topic: "%s"' % existing_topic)
                         await topic_unsubscribe_request(existing_topic)
 
+
+            # Subscribe to topics not in subscriber list
             for i in incoming_topics:
                 topic = i[0]
                 msg_type = i[1][0]


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR adds functionality to the ros2 nats bridge to be able to unsubscribe from all topics if an empty list request is sent.
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CDA Telematics Contributing Guide](https://github.com/usdot-fhwa-stol/cda-telematics/blob/main/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
