### PR TITLE
Update docker image names to match dockerhub image names and add cyclone url

### DIFF
--- a/telematic_system/docker-compose.units.yml
+++ b/telematic_system/docker-compose.units.yml
@@ -4,7 +4,7 @@ services:
     build:
           context: ./telematic_units/carma_vehicle_bridge
           dockerfile: Dockerfile
-    image: usdotfhwastoldev/carma_vehicle_bridge:develop
+    image: usdotfhwastoldev/carma_vehicle_nats_bridge:develop
     container_name: carma_vehicle_bridge
     network_mode: host
     entrypoint: /ws/ros_entrypoint.sh
@@ -18,6 +18,7 @@ services:
     - VEHICLE_BRIDGE_LOG_LEVEL=debug
     - VEHICLE_BRIDGE_LOG_NAME=ros2_nats_bridge
     - VEHICLE_BRIDGE_LOG_PATH=/var/logs/
+    - CYCLONE_URL=./telematic_units/cyclone_config.xml
     - VEHICLE_BRIDGE_LOG_ROTATION_SIZE_BYTES=2147483648 #2 gigabytes
     - VEHICLE_BRIDGE_LOG_HANDLER_TYPE=console #console: Print logs on console; file: Save logs to file; all: Prints logs on console and file
     - VEHICLE_BRIDGE_EXCLUSION_LIST= /environment/map_filtered_points,
@@ -39,7 +40,7 @@ services:
     build:
           context: ./telematic_units/carma_street_bridge
           dockerfile: Dockerfile
-    image: usdotfhwastoldev/carma_street_bridge:develop
+    image: usdotfhwastoldev/carma_street_nats_bridge:develop
     container_name: carma_street_bridge
     network_mode: host
     volumes:
@@ -63,7 +64,7 @@ services:
     build:
           context: ./telematic_units/carma_cloud_bridge
           dockerfile: Dockerfile
-    image: usdotfhwastoldev/carma_cloud_bridge:develop
+    image: usdotfhwastoldev/carma_cloud_nats_bridge:develop
     container_name: carma_cloud_bridge
     network_mode: host
     volumes:


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
- The telematic unit docker image names in the docker-compose.unit.yml file do not match dockerhub image names.
- The cyclone config url needs to be added to environment variable for carma-vehicle-bridge
<!--- Describe your changes in detail -->

## Related Issue
NA
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
cda-telematics
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration testing with white Fusion
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CDA Telematics Contributing Guide](https://github.com/usdot-fhwa-stol/cda-telematics/blob/main/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
