### PR TITLE
add metadata refresh rate for kafka

### DIFF
--- a/telematic_system/docker-compose.units.yml
+++ b/telematic_system/docker-compose.units.yml
@@ -58,6 +58,7 @@ services:
     - NATS_IP=<IP> #REQUIRED variable, replace IP with IP address of NATS server
     - NATS_PORT=4222
     - KAFKA_CONSUMER_RESET=earliest
+    - KAFKA_REFRESH_RATE=60000 #The period of time in milliseconds after which we force a refresh of metadata
     - STREETS_BRIDGE_EXCLUSION_LIST= #OPTIONAL variable to set a comma separated list of topics not available to publish, leave empty if none
   
   cloud-nats-bridge:

--- a/telematic_system/telematic_units/carma_street_bridge/streets_nats_bridge/src/streets_nats_bridge.py
+++ b/telematic_system/telematic_units/carma_street_bridge/streets_nats_bridge/src/streets_nats_bridge.py
@@ -67,6 +67,8 @@ class StreetsNatsBridge():
         self.log_rotation = int(os.getenv('STREETS_BRIDGE_LOG_ROTATION_SIZE_BYTES'))
         self.kafka_offset_reset = os.getenv('KAFKA_CONSUMER_RESET')
 
+        self.kafka_refresh_rate = os.getenv('KAFKA_REFRESH_RATE')
+
         self.unit_name = "West Intersection"
         self.nc = NATS()
         self.streets_topics = []  # list of available carma-streets topic
@@ -140,12 +142,12 @@ class StreetsNatsBridge():
         try:
             self.logger.info(" In run_async_kafka_consumer: ")
             # auto_offset_reset handles where consumer restarts reading after breaking down or being turned off
-            # auto_offset_reset handles where consumer restarts reading after breaking down or being turned off
-            # auto_offset_reset handles where consumer restarts reading after breaking down or being turned off
+            # metadata_max_age_ms (int) – The period of time in milliseconds after which we force a refresh of metadata. Default: 300000ms
             # ("latest" --> start reading at the end of the log, "earliest" --> start reading at latest committed offset)
             # group_id is the consumer group to which this belongs (consumer needs to be part of group to make auto commit work)
             self.kafka_consumer = AIOKafkaConsumer(
                 bootstrap_servers=[self.kafka_ip+":"+self.kafka_port],
+                metadata_max_age_ms=self.kafka_refresh_rate,
                 auto_offset_reset=self.kafka_offset_reset,
                 enable_auto_commit=True,
                 group_id=None,


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Adds a configurable parameter for metadata refresh rate in carma-streets bridge kafka consumer. The default if not set is 5mins, so adding the parameter allows new published topics to be discovered quicker.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CDA Telematics Contributing Guide](https://github.com/usdot-fhwa-stol/cda-telematics/blob/main/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
