### PR TITLE
Full integration testing issue: Streets NATS bridge timestamp conversion for modified_spat is inaccurate

### DIFF
--- a/telematic_system/telematic_units/carma_street_bridge/streets_nats_bridge/src/streets_nats_bridge.py
+++ b/telematic_system/telematic_units/carma_street_bridge/streets_nats_bridge/src/streets_nats_bridge.py
@@ -218,7 +218,7 @@ class StreetsNatsBridge():
                         message["timestamp"] = timestamp
                     #do special conversion for spat message using moy
                     elif topic == "modified_spat":
-                        timestamp = int(message["payload"]["time_stamp"])
+                        timestamp = int(message["payload"]["intersections"][0]["time_stamp"])
                         moy = int(message["payload"]["intersections"][0]["moy"])
                         #Use moy and timestamp fields to get epoch time for each record
                         epoch_micro = int((moy* minuteToMilli) + timestamp + first_day_epoch)*milliToMicro #convert moy to microseconds    


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Streets NATS bridge timestamp conversion for modified_spat is inaccurate
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/cda-telematics/issues/104
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
WFD integration testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CDA Telematics Contributing Guide](https://github.com/usdot-fhwa-stol/cda-telematics/blob/main/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
