### PR TITLE
Cloud NATS Bridge  throw index out of range error

### DIFF
--- a/telematic_system/telematic_units/carma_cloud_bridge/cloud_nats_bridge/src/cloud_nats_bridge/cloud_nats_bridge.py
+++ b/telematic_system/telematic_units/carma_cloud_bridge/cloud_nats_bridge/src/cloud_nats_bridge/cloud_nats_bridge.py
@@ -74,6 +74,8 @@ class FileListener(FileSystemEventHandler):
                     newLine = line
 
                     #convert carma cloud timestamp and current date to time since epoch
+                    if newLine.split(" ").__len__() < 2:
+                        continue
                     timestamp = newLine.split(" ")[1]
                     date = self.today.strftime("%m/%d/%y")
                     datetime = date + " " + timestamp


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Cloud NATS Bridge  throw index out of range error
<!--- Describe your changes in detail -->
![image (2)](https://user-images.githubusercontent.com/62157949/228309037-7f96113c-65c7-43ee-9523-e7b6432cdb69.png)

## Related Issue
https://github.com/usdot-fhwa-stol/cda-telematics/issues/121
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
WFD full integration testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CDA Telematics Contributing Guide](https://github.com/usdot-fhwa-stol/cda-telematics/blob/main/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
