### PR TITLE
fix unsubscribe logic in vehicle nats bridge

### DIFF
--- a/telematic_system/telematic_units/carma_vehicle_bridge/ros2_nats_bridge/ros2_nats_bridge/api.py
+++ b/telematic_system/telematic_units/carma_vehicle_bridge/ros2_nats_bridge/ros2_nats_bridge/api.py
@@ -261,10 +261,15 @@ class Ros2NatsBridgeNode(Node):
 
             # Remove topics from subscribers list that weren't called in new request
             for existing_topic in list(self.subscribers_list.keys()):
+                is_topic_in_list = False
                 for topics in incoming_topics:
-                    if (existing_topic != topics[0]):
-                        self.logger.info('Trying to unsubscribe from topic: "%s"' % existing_topic)
-                        await topic_unsubscribe_request(existing_topic)
+                    if (existing_topic == topics[0]):
+                        is_topic_in_list = True
+                        break
+
+                if not is_topic_in_list:
+                    self.logger.info('Trying to unsubscribe from topic: "%s"' % existing_topic)
+                    await topic_unsubscribe_request(existing_topic)
 
             # Subscribe to topics not in subscriber list
             for i in incoming_topics:


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Fixes an issue where trying to unsubscribe from ros2 topic causes multiple subscriptions.
## Description
During the verification testing, the UI is trying to send request to unsubscribe /message/bsm_outbound, but the vehicle bridge unsubscribe both /message/incoming_bsm and /message/bsm_outbound topics
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/cda-telematics/issues/127
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CDA Telematics Contributing Guide](https://github.com/usdot-fhwa-stol/cda-telematics/blob/main/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
