### PR TITLE
Use system time for CDASim

### DIFF
--- a/telematic_system/docker-compose.units.yml
+++ b/telematic_system/docker-compose.units.yml
@@ -26,6 +26,7 @@ services:
     - VEHICLE_BRIDGE_LOG_ROTATION_SIZE_BYTES=2147483648 #2 gigabytes
     - VEHICLE_BRIDGE_LOG_HANDLER_TYPE=console #console: Print logs on console; file: Save logs to file; all: Prints logs on console and file
     - VEHICLE_BRIDGE_EXCLUSION_LIST= ${VEHICLE_BRIDGE_EXCLUSION_LIST} #OPTIONAL variable to set a comma separated list of topics not available to publish, leave empty if none
+    - IS_SIM=False
 
   streets-nats-bridge:
     build:

--- a/telematic_system/docker-compose.units.yml
+++ b/telematic_system/docker-compose.units.yml
@@ -26,7 +26,7 @@ services:
     - VEHICLE_BRIDGE_LOG_ROTATION_SIZE_BYTES=2147483648 #2 gigabytes
     - VEHICLE_BRIDGE_LOG_HANDLER_TYPE=console #console: Print logs on console; file: Save logs to file; all: Prints logs on console and file
     - VEHICLE_BRIDGE_EXCLUSION_LIST= ${VEHICLE_BRIDGE_EXCLUSION_LIST} #OPTIONAL variable to set a comma separated list of topics not available to publish, leave empty if none
-    - IS_SIM=False
+    - IS_SIM=False #OPTIONAL variable to treat incoming messages as coming from simulation env.  In this case The bridge will use system time as message timestamp. Defaults to False
 
   streets-nats-bridge:
     build:

--- a/telematic_system/docker-compose.units.yml
+++ b/telematic_system/docker-compose.units.yml
@@ -26,7 +26,7 @@ services:
     - VEHICLE_BRIDGE_LOG_ROTATION_SIZE_BYTES=2147483648 #2 gigabytes
     - VEHICLE_BRIDGE_LOG_HANDLER_TYPE=console #console: Print logs on console; file: Save logs to file; all: Prints logs on console and file
     - VEHICLE_BRIDGE_EXCLUSION_LIST= ${VEHICLE_BRIDGE_EXCLUSION_LIST} #OPTIONAL variable to set a comma separated list of topics not available to publish, leave empty if none
-    - IS_SIM=False #OPTIONAL variable to treat incoming messages as coming from simulation env.  In this case The bridge will use system time as message timestamp. Defaults to False
+    - IS_SIM=False #OPTIONAL variable to treat incoming messages as coming from simulation env.  In this case the bridge will use system time as message timestamp. Defaults to False.
 
   streets-nats-bridge:
     build:

--- a/telematic_system/telematic_units/carma_vehicle_bridge/ros2_nats_bridge/ros2_nats_bridge/api.py
+++ b/telematic_system/telematic_units/carma_vehicle_bridge/ros2_nats_bridge/ros2_nats_bridge/api.py
@@ -338,7 +338,7 @@ class Ros2NatsBridgeNode(Node):
             nanosecondToSecond = 0.000000001 #convert nanoseconds to seconds
             secondToMicro = 1000000 #convert seconds to microseconds
 
-            # If CDASim use current system time instead of ros header time
+            # If simulation environment - use current system time instead of ros header time
             if self.is_sim :
                 ordereddict_msg["timestamp"] = datetime.now(timezone.utc).timestamp()*secondToMicro  # microseconds
             else:   

--- a/telematic_system/telematic_units/carma_vehicle_bridge/ros2_nats_bridge/ros2_nats_bridge/api.py
+++ b/telematic_system/telematic_units/carma_vehicle_bridge/ros2_nats_bridge/ros2_nats_bridge/api.py
@@ -61,7 +61,7 @@ class Ros2NatsBridgeNode(Node):
         self.exclusion_list = []
         
         # Get is_sim env variable as boolean
-        self.is_sim = os.getenv("IS_SIM", 'False').lower() in ('true', '1', 't')
+        self.is_sim = os.getenv("IS_SIM", 'False').lower() in ('true', '1')
 
         self.vehicle_info = {
             UnitKeys.UNIT_ID.value: os.getenv("VEHICLE_BRIDGE_UNIT_ID"),

--- a/telematic_system/telematic_units/carma_vehicle_bridge/ros2_nats_bridge/ros2_nats_bridge/api.py
+++ b/telematic_system/telematic_units/carma_vehicle_bridge/ros2_nats_bridge/ros2_nats_bridge/api.py
@@ -59,6 +59,9 @@ class Ros2NatsBridgeNode(Node):
         self.registered = False
         self.subscribers_list = {}
         self.exclusion_list = []
+        
+        # Get is_sim env variable as boolean
+        self.is_sim = os.getenv("IS_SIM", 'False').lower() in ('true', '1', 't')
 
         self.vehicle_info = {
             UnitKeys.UNIT_ID.value: os.getenv("VEHICLE_BRIDGE_UNIT_ID"),
@@ -75,7 +78,6 @@ class Ros2NatsBridgeNode(Node):
         self.log_rotation = int(os.getenv("VEHICLE_BRIDGE_LOG_ROTATION_SIZE_BYTES"))
         
         self.log_handler_type = os.getenv('VEHICLE_BRIDGE_LOG_HANDLER_TYPE')
-        self.is_sim = os.getenv('IS_SIM')
 
         # Create ROS2NatsBridge logger
         if self.log_handler_type == LogType.ALL.value:
@@ -277,7 +279,8 @@ class Ros2NatsBridgeNode(Node):
                     exec("from " + msg_type[0] + '.' +
                             msg_type[1] + " import " + msg_type[2])
                     call_back = self.CallBack(i[1][0], topic, self.nc, self.vehicle_info[UnitKeys.UNIT_ID.value], self.vehicle_info[UnitKeys.UNIT_TYPE.value],
-                                                self.vehicle_info[UnitKeys.UNIT_NAME.value], self.vehicle_info[EventKeys.EVENT_NAME.value], self.vehicle_info[EventKeys.TESTING_TYPE.value], self.vehicle_info[EventKeys.LOCATION.value], self.logger)
+                                                self.vehicle_info[UnitKeys.UNIT_NAME.value], self.vehicle_info[EventKeys.EVENT_NAME.value], self.vehicle_info[EventKeys.TESTING_TYPE.value], self.vehicle_info[EventKeys.LOCATION.value], 
+                                                self.is_sim, self.logger)
                     try:
                         self.subscribers_list[topic] = self.create_subscription(
                             eval(msg_type[2]), topic, call_back.listener_callback, 10)
@@ -299,7 +302,7 @@ class Ros2NatsBridgeNode(Node):
 
 
     class CallBack():
-        def __init__(self, msg_type, topic_name, nc, unit_id, unit_type, unit_name, event_name, testing_type, location, logger):
+        def __init__(self, msg_type, topic_name, nc, unit_id, unit_type, unit_name, event_name, testing_type, location, is_sim, logger):
             """
                 initilize CallBack class
                 declare Nats client 
@@ -317,6 +320,7 @@ class Ros2NatsBridgeNode(Node):
             self.logger = logger
             self.logger.info("Publishing on topic: "+ self.topic_name)
             self.nc = nc
+            self.is_sim = is_sim
 
         async def listener_callback(self, msg):
             """
@@ -339,7 +343,7 @@ class Ros2NatsBridgeNode(Node):
             secondToMicro = 1000000 #convert seconds to microseconds
 
             # If simulation environment - use current system time instead of ros header time
-            if self.is_sim :
+            if self.is_sim:
                 ordereddict_msg["timestamp"] = datetime.now(timezone.utc).timestamp()*secondToMicro  # microseconds
             else:   
                 #Check if the ROS message has a timestamp and use it for the NATS message


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Adds environment variable to check if ros2 nats bridge is being run in simulation environment. In case it is, the ros messages are stamped to system time at time of processing in the bridge.

This is required since the the ros message headers are stamped to simulation time which may not be reasonable values to plot on the dashboard.
## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CDA Telematics Contributing Guide](https://github.com/usdot-fhwa-stol/cda-telematics/blob/main/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
