### PR TITLE
Update all container and images name to be consistent

### DIFF
--- a/telematic_system/docker-compose.cloud.servers.yml
+++ b/telematic_system/docker-compose.cloud.servers.yml
@@ -2,6 +2,7 @@ version: "3"
 services:
   nats:
     image: 'nats:2.7.3-alpine3.15'
+    container_name: nats
     restart: always
     logging:
       options:
@@ -9,9 +10,10 @@ services:
         max-file: "1"
     network_mode: host
 
-  telematic_messaging_server:
+  messaging_server:
     build:
       context: "./telematic_cloud_messaging"
+    container_name: messaging_server
     depends_on:
       - nats
     restart: always

--- a/telematic_system/docker-compose.dbs.yml
+++ b/telematic_system/docker-compose.dbs.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   influxdb:
     image:  influxdb:${INFLUXDB_DEV_TAG} 
-    container_name: influxdb-dev
+    container_name: influxdb
     ports:
       - '8086:8086'
     restart: always

--- a/telematic_system/docker-compose.historical.yml
+++ b/telematic_system/docker-compose.historical.yml
@@ -1,11 +1,10 @@
 version: "3.4"
 services:
-  rosbag2-processing-service:
+  rosbag2_processing_service:
     build:
           context: ./telematic_historical_data_processing
           dockerfile: Dockerfile
           network: host
-    image: usdotfhwastoldev/rosbag2_processing_service:develop
     logging:
       options:
         max-size: "2g"

--- a/telematic_system/docker-compose.local.yml
+++ b/telematic_system/docker-compose.local.yml
@@ -3,7 +3,7 @@ services:
 
   influxdb:
     image:  influxdb:${INFLUXDB_DEV_TAG}
-    container_name: influxdb-dev
+    container_name: influxdb
     ports:
       - '8086:8086'
     restart: always
@@ -27,6 +27,7 @@ services:
   mysqldb:
     image: mysql:5.7
     restart: always
+    container_name: mysqldb
     environment:
       - MYSQL_DATABASE=${MYSQL_DATABASE}
       - MYSQL_USER=${MYSQL_USER}
@@ -43,6 +44,7 @@ services:
   nats:
     image: 'nats:2.7.3-alpine3.15'
     restart: always
+    container_name: nats
     logging:
       options:
         max-size: "2g"
@@ -53,6 +55,7 @@ services:
       build:
         context: "./telematic_apps/grafana"
       restart: always
+      container_name: grafana
       logging:
         options:
           max-size: "10m"
@@ -69,11 +72,12 @@ services:
         - /home/ubuntu/.aws/credentials:/usr/share/grafana/.aws/credentials
       user: "472" #grafana user id
 
-  telematic_web_server:
+  web_server:
       build:
         context: "./telematic_apps/web_app/server"
         dockerfile: "local.Dockerfile"
       restart: always
+      container_name: web_server
       logging:
         options:
           max-size: "10m"
@@ -119,23 +123,25 @@ services:
         - /opt/apache2/grafana_htpasswd:/opt/apache2/grafana_htpasswd
         - /opt/telematics/upload:/opt/telematics/upload
 
-  telematic_web_client:
+  web_client:
     build:
       context: "./telematic_apps/web_app/client"
     restart: always
+    container_name: web_client
     logging:
       options:
         max-size: "10m"
         max-file: "1"
     network_mode: host
     depends_on:
-      - telematic_web_server
+      - web_server
 
   apache2:
     build:
       context: "./telematic_apps/apache2"
       dockerfile: "./local.Dockerfile"
     restart: always
+    container_name: apache2
     logging:
       options:
         max-size: "10m"
@@ -149,15 +155,16 @@ services:
       - UISERVICE_LOCAL_UPLOAD_URL=http://127.0.0.1:9011/
     depends_on:
       - grafana
-      - telematic_web_client
-      - telematic_web_server
+      - web_client
+      - web_server
     volumes:
       - /opt/apache2/grafana_htpasswd:/etc/apache2/grafana_htpasswd
 
-  telematic_messaging_server:
+  messaging_server:
     build:
       context: "./telematic_cloud_messaging"
       dockerfile: "local.Dockerfile"
+    container_name: messaging_server
     depends_on:
       - nats
       - mysqldb
@@ -175,12 +182,12 @@ services:
       - WAIT_SLEEP_INTERVAL=5
       - WAIT_HOST_CONNECT_TIMEOUT=30
 
-  rosbag2-processing-service:
+  rosbag2_processing_service:
     build:
           context: ./telematic_historical_data_processing
           dockerfile: Dockerfile
           network: host
-    image: usdotfhwastoldev/rosbag2_processing_service:develop
+    container_name: rosbag2_processing_service
     restart: always
     depends_on:
       - nats
@@ -190,7 +197,6 @@ services:
       options:
         max-size: "2g"
         max-file: "1"
-    container_name: rosbag2_processing_service
     network_mode: host
     entrypoint: /ws/entrypoint.sh
     volumes:

--- a/telematic_system/docker-compose.units.yml
+++ b/telematic_system/docker-compose.units.yml
@@ -1,6 +1,6 @@
 version: "3.4"
 services:
-  ros2-nats-bridge:
+  ros2_nats_bridge:
     build:
           context: ./telematic_units/carma_vehicle_bridge
           dockerfile: Dockerfile
@@ -9,7 +9,7 @@ services:
       options:
         max-size: "2g"
         max-file: "1"
-    container_name: carma_vehicle_bridge
+    container_name: ros2_nats_bridge
     network_mode: host
     entrypoint: /ws/ros_entrypoint.sh
     volumes:
@@ -28,7 +28,7 @@ services:
     - VEHICLE_BRIDGE_EXCLUSION_LIST= ${VEHICLE_BRIDGE_EXCLUSION_LIST} #OPTIONAL variable to set a comma separated list of topics not available to publish, leave empty if none
     - IS_SIM=False #OPTIONAL variable to treat incoming messages as coming from simulation env.  In this case the bridge will use system time as message timestamp. Defaults to False.
 
-  streets-nats-bridge:
+  streets_nats_bridge:
     build:
           context: ./telematic_units/carma_street_bridge
           dockerfile: Dockerfile
@@ -37,7 +37,7 @@ services:
       options:
         max-size: "2g"
         max-file: "1"
-    container_name: carma_street_bridge
+    container_name: streets_nats_bridge
     network_mode: host
     volumes:
            - ./logs:/var/logs
@@ -56,7 +56,7 @@ services:
     - STREETS_BRIDGE_EXCLUSION_LIST= ${STREETS_BRIDGE_EXCLUSION_LIST} #OPTIONAL variable to set a comma separated list of topics not available to publish, leave empty if none
     - IS_SIM=False #OPTIONAL variable to treat incoming messages as coming from simulation env.  In this case the bridge will use system time as message timestamp. Defaults to False.
 
-  cloud-nats-bridge:
+  cloud_nats_bridge:
     build:
           context: ./telematic_units/carma_cloud_bridge
           dockerfile: Dockerfile
@@ -65,7 +65,7 @@ services:
       options:
         max-size: "2g"
         max-file: "1"
-    container_name: carma_cloud_bridge
+    container_name: cloud_nats_bridge
     network_mode: host
     volumes:
            - ./logs:/var/logs

--- a/telematic_system/docker-compose.webapp.yml
+++ b/telematic_system/docker-compose.webapp.yml
@@ -1,9 +1,10 @@
 version: "3"
 services:
-  telematic_web_server:
+  web_server:
       build:
         context: "./telematic_apps/web_app/server"
       restart: always
+      container_name: web_server
       logging:
         options:
           max-size: "10m"
@@ -41,17 +42,18 @@ services:
         - /opt/apache2/grafana_htpasswd:/opt/apache2/grafana_htpasswd
         - /opt/telematics/upload:/opt/telematics/upload
 
-  telematic_web_client:
+  web_client:
     build:
       context: "./telematic_apps/web_app/client"
     restart: always
+    container_name: web_client
     logging:
       options:
         max-size: "10m"
         max-file: "1"
     network_mode: host
     depends_on:
-      - telematic_web_server
+      - web_server
     volumes:
       - ./web_client.production.env.js:/usr/share/nginx/html/env.js
 
@@ -59,6 +61,7 @@ services:
     build:
       context: "./telematic_apps/apache2"
     restart: always
+    container_name: apache2
     logging:
       options:
         max-size: "10m"
@@ -72,8 +75,8 @@ services:
       - UISERVICE_LOCAL_UPLOAD_URL=http://127.0.0.1:9011/
     depends_on:
       - grafana
-      - telematic_web_client
-      - telematic_web_server
+      - web_client
+      - web_server
     volumes:
       - /opt/apache2/grafana_htpasswd:/etc/apache2/grafana_htpasswd
 
@@ -81,6 +84,7 @@ services:
     build:
       context: "./telematic_apps/grafana"
     restart: always
+    container_name: grafana
     logging:
       options:
         max-size: "10m"


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Update all container and images name to be consistent
<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context
Integration testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
