### PR TITLE
Historical Data Processing section on UI doesn't allow log file upload from Firefox browsers

### DIFF
--- a/telematic_system/telematic_apps/web_app/client/src/components/ros2_rosbag/ROS2RosbagUploadDialog.js
+++ b/telematic_system/telematic_apps/web_app/client/src/components/ros2_rosbag/ROS2RosbagUploadDialog.js
@@ -47,7 +47,7 @@ const ROS2RosbagUploadDialog = (props) => {
       filesInfo.push({
         filename: file.name,
         filetype: file.type,
-        datetime: file.lastModifiedDate.toLocaleString(),
+        datetime: file.lastModifiedDate?.toLocaleString(),
         filesize: calFilesizes(file.size),
         description: "",
       });


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Fix file  upload table population.
<!--- Describe your changes in detail -->

## Related GitHub Issue
https://github.com/usdot-fhwa-stol/cda-telematics/issues/199
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
