### PR TITLE
update image names to release candidate

### DIFF
--- a/telematic_system/docker-compose.cloud.servers.yml
+++ b/telematic_system/docker-compose.cloud.servers.yml
@@ -15,7 +15,7 @@ services:
       context: "./telematic_cloud_messaging"
     container_name: messaging_server
     #Todo: The cloud messaging service image has incorrect configuration. Please update the application.properties, and build it from source code.
-    image: usdotfhwastoldev/telematic_cloud_messaging:develop
+    image: usdotfhwastolcandidate/telematic_cloud_messaging:neon
     depends_on:
       - nats
     restart: always
@@ -27,13 +27,13 @@ services:
     command: bash -c 'wait-for-it localhost:4222 && java -jar /telematic_cloud_messaging/app.jar'
     env_file:
       - .env
-  
+
   rosbag2_processing_service:
     build:
           context: ./telematic_historical_data_processing
           dockerfile: Dockerfile
           network: host
-    image: usdotfhwastoldev/telematic_historical_data_processing:develop
+    image: usdotfhwastolcandidate/telematic_historical_data_processing:neon
     network_mode: host
     logging:
       options:

--- a/telematic_system/docker-compose.local.yml
+++ b/telematic_system/docker-compose.local.yml
@@ -51,7 +51,7 @@ services:
   grafana:
       build:
         context: "./telematic_apps/grafana"
-      image: usdotfhwastoldev/telematic_grafana:develop
+      image: usdotfhwastolcandidate/telematic_grafana:neon
       restart: always
       container_name: grafana
       logging:
@@ -74,7 +74,7 @@ services:
       build:
         context: "./telematic_apps/web_app/server"
         dockerfile: "Dockerfile"
-      image: usdotfhwastoldev/telematic_web_server:develop
+      image: usdotfhwastolcandidate/telematic_web_server:neon
       restart: always
       container_name: web_server
       logging:
@@ -95,7 +95,7 @@ services:
   web_client:
     build:
       context: "./telematic_apps/web_app/client"
-    image: usdotfhwastoldev/telematic_web_client:develop
+    image: usdotfhwastolcandidate/telematic_web_client:neon
     restart: always
     container_name: web_client
     logging:
@@ -110,7 +110,7 @@ services:
     build:
       context: "./telematic_apps/apache2"
       dockerfile: "./local.Dockerfile"
-    image: usdotfhwastoldev/telematic_local_apache2:develop
+    image: usdotfhwastolcandidate/telematic_local_apache2:neon
     restart: always
     container_name: apache2
     logging:
@@ -135,7 +135,7 @@ services:
     build:
       context: "./telematic_cloud_messaging"
     container_name: messaging_server
-    image: usdotfhwastoldev/telematic_local_messaging:develop
+    image: usdotfhwastolcandidate/telematic_local_messaging:neon
     depends_on:
       - nats
       - mysqldb
@@ -155,7 +155,7 @@ services:
           context: ./telematic_historical_data_processing
           dockerfile: Dockerfile
           network: host
-    image: usdotfhwastoldev/telematic_historical_data_processing:develop
+    image: usdotfhwastolcandidate/telematic_historical_data_processing:neon
     container_name: rosbag2_processing_service
     restart: always
     depends_on:

--- a/telematic_system/docker-compose.units.yml
+++ b/telematic_system/docker-compose.units.yml
@@ -4,7 +4,7 @@ services:
     build:
           context: ./telematic_units/carma_vehicle_bridge
           dockerfile: Dockerfile
-    image: usdotfhwastoldev/carma_vehicle_nats_bridge:develop
+    image: usdotfhwastolcandidate/carma_vehicle_nats_bridge:neon
     logging:
       options:
         max-size: "2g"
@@ -32,7 +32,7 @@ services:
     build:
           context: ./telematic_units/carma_street_bridge
           dockerfile: Dockerfile
-    image: usdotfhwastoldev/carma_street_nats_bridge:develop
+    image: usdotfhwastolcandidate/carma_street_nats_bridge:neon
     logging:
       options:
         max-size: "2g"
@@ -60,7 +60,7 @@ services:
     build:
           context: ./telematic_units/carma_cloud_bridge
           dockerfile: Dockerfile
-    image: usdotfhwastoldev/carma_cloud_nats_bridge:develop
+    image: usdotfhwastolcandidate/carma_cloud_nats_bridge:neon
     logging:
       options:
         max-size: "2g"

--- a/telematic_system/docker-compose.webapp.yml
+++ b/telematic_system/docker-compose.webapp.yml
@@ -5,7 +5,7 @@ services:
         context: "./telematic_apps/web_app/server"
       restart: always
       container_name: web_server
-      image: usdotfhwastoldev/telematic_web_server:develop
+      image: usdotfhwastolcandidate/telematic_web_server:neon
       logging:
         options:
           max-size: "10m"
@@ -35,11 +35,11 @@ services:
         - UPLOAD_HTTP_PORT=9011
         - UPLOAD_TIME_OUT=3600000 # Milliseconds
         - UPLOAD_MAX_FILE_SIZE=21474836480 #20 GB
-        - CONCURRENT_QUEUE_SIZE=5 
-        - PART_SIZE=10485760 
+        - CONCURRENT_QUEUE_SIZE=5
+        - PART_SIZE=10485760
         - NATS_SERVERS=<NATS_IP>:4222
         - FILE_PROCESSING_SUBJECT=ui.file.processing
-        - FILE_EXTENSIONS=.mcap 
+        - FILE_EXTENSIONS=.mcap
       command: bash -c '/app/service.sh'
       volumes:
         - /opt/apache2/grafana_htpasswd:/opt/apache2/grafana_htpasswd
@@ -48,7 +48,7 @@ services:
   web_client:
     build:
       context: "./telematic_apps/web_app/client"
-    image: usdotfhwastoldev/telematic_web_client:develop
+    image: usdotfhwastolcandidate/telematic_web_client:neon
     restart: always
     container_name: web_client
     logging:
@@ -65,7 +65,7 @@ services:
     build:
       context: "./telematic_apps/apache2"
     restart: always
-    image: usdotfhwastoldev/telematic_apache2:develop
+    image: usdotfhwastolcandidate/telematic_apache2:neon
     container_name: apache2
     logging:
       options:
@@ -88,7 +88,7 @@ services:
   grafana:
     build:
       context: "./telematic_apps/grafana"
-    image: usdotfhwastoldev/telematic_grafana:develop
+    image: usdotfhwastolcandidate/telematic_grafana:neon
     restart: always
     container_name: grafana
     logging:


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
This PR updates the image names in the docker-compose for services to point to the release candidate for neon.

## Description

<!--- Describe your changes in detail -->

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
