### PR TITLE
Fix the issue with influxDB parsing for line protocol failed

### DIFF
--- a/telematic_system/telematic_rsu_management_service/src/main/java/com/telematic/telematic_rsu_management_service/data_ingestion/influx/InfluxLineBuilder.java
+++ b/telematic_system/telematic_rsu_management_service/src/main/java/com/telematic/telematic_rsu_management_service/data_ingestion/influx/InfluxLineBuilder.java
@@ -73,7 +73,7 @@ public class InfluxLineBuilder {
         } else if (node.isArray()) {
             int idx = 0;
             for (JsonNode item : node) {
-                String key = prefix + "[" + idx + "]";
+                String key = prefix + "." + idx;
                 flatten(key, item, out);
                 idx++;
             }

--- a/telematic_system/telematic_rsu_management_service/src/test/java/com/telematic/telematic_rsu_management_service/data_ingestion/influx/InfluxLineBuilderTest.java
+++ b/telematic_system/telematic_rsu_management_service/src/test/java/com/telematic/telematic_rsu_management_service/data_ingestion/influx/InfluxLineBuilderTest.java
@@ -159,12 +159,12 @@ class InfluxLineBuilderTest {
             .thenAnswer(invocation -> {
                 LineRecordContext ctx = invocation.getArgument(0);
                 assertEquals("array_event", ctx.getMeasurement());
-                assertTrue(ctx.getFields().containsKey("payload.values[0]"));
-                assertTrue(ctx.getFields().containsKey("payload.values[1]"));
-                assertTrue(ctx.getFields().containsKey("payload.values[2]"));
-                assertTrue(ctx.getFields().containsKey("payload.names[0]"));
-                assertTrue(ctx.getFields().containsKey("payload.names[1]"));
-                assertTrue(ctx.getFields().containsKey("payload.names[2]"));
+                assertTrue(ctx.getFields().containsKey("payload.values.0"));
+                assertTrue(ctx.getFields().containsKey("payload.values.1"));
+                assertTrue(ctx.getFields().containsKey("payload.values.2"));
+                assertTrue(ctx.getFields().containsKey("payload.names.0"));
+                assertTrue(ctx.getFields().containsKey("payload.names.1"));
+                assertTrue(ctx.getFields().containsKey("payload.names.2"));
                 return "mocked_line_with_arrays";
             });
 
@@ -321,10 +321,10 @@ class InfluxLineBuilderTest {
             .thenAnswer(invocation -> {
                 LineRecordContext ctx = invocation.getArgument(0);
                 assertTrue(ctx.getFields().containsKey("payload.level1.level2.level3.deepValue"));
-                assertTrue(ctx.getFields().containsKey("payload.mixedArray[0].id"));
-                assertTrue(ctx.getFields().containsKey("payload.mixedArray[0].name"));
-                assertTrue(ctx.getFields().containsKey("payload.mixedArray[1].id"));
-                assertTrue(ctx.getFields().containsKey("payload.mixedArray[1].name"));
+                assertTrue(ctx.getFields().containsKey("payload.mixedArray.0.id"));
+                assertTrue(ctx.getFields().containsKey("payload.mixedArray.0.name"));
+                assertTrue(ctx.getFields().containsKey("payload.mixedArray.1.id"));
+                assertTrue(ctx.getFields().containsKey("payload.mixedArray.1.name"));
                 return "complex_line";
             });
 
@@ -333,6 +333,177 @@ class InfluxLineBuilderTest {
 
         // Then
         assertEquals("complex_line", result);
+        verify(pipelineLineBuilder, times(1)).build(any(LineRecordContext.class));
+    }
+
+    @Test
+    void testBuildLine_withBsmPayload() throws Exception {
+        // Given – trimmed J2735 BSM structure matching real RSU output
+        String json = """
+            {
+                "metadata": {
+                    "event": "IntegrationTest2",
+                    "unitId": "Unit001",
+                    "rsu": {
+                        "ip": "192.168.55.73",
+                        "port": "161"
+                    },
+                    "topicName": "J2735_BSM_MessageReceiver",
+                    "timestamp": 1773256928799
+                },
+                "payload": {
+                    "channel": -1,
+                    "encoding": "asn.1-uper/hexstring",
+                    "flags": 0,
+                    "payload": {
+                        "messageId": 20,
+                        "value": {
+                            "BasicSafetyMessage": {
+                                "coreData": {
+                                    "msgCnt": 33,
+                                    "id": "2DC05B91",
+                                    "secMark": 8599,
+                                    "lat": 389563900,
+                                    "long": -771504776,
+                                    "elev": 305,
+                                    "heading": 27488,
+                                    "speed": 2,
+                                    "transmission": "unavailable",
+                                    "angle": 127,
+                                    "accelSet": {
+                                        "long": 8,
+                                        "lat": 2001,
+                                        "vert": -127,
+                                        "yaw": 0
+                                    },
+                                    "brakes": {
+                                        "wheelBrakes": 80,
+                                        "traction": "unavailable",
+                                        "abs": "unavailable",
+                                        "scs": "unavailable",
+                                        "brakeBoost": "unavailable",
+                                        "auxBrakes": "unavailable"
+                                    },
+                                    "accuracy": {
+                                        "semiMajor": 11,
+                                        "semiMinor": 11,
+                                        "orientation": 0
+                                    },
+                                    "size": {
+                                        "width": 0,
+                                        "length": 0
+                                    }
+                                },
+                                "partII": [
+                                    {
+                                        "partII-Id": 0,
+                                        "partII-Value": {
+                                            "VehicleSafetyExtensions": {
+                                                "pathPrediction": {
+                                                    "radiusOfCurve": 32767,
+                                                    "confidence": 200
+                                                },
+                                                "pathHistory": {
+                                                    "crumbData": [
+                                                        {
+                                                            "elevationOffset": -27,
+                                                            "latOffset": -143,
+                                                            "lonOffset": 220,
+                                                            "timeOffset": 1150
+                                                        },
+                                                        {
+                                                            "elevationOffset": -48,
+                                                            "latOffset": -200,
+                                                            "lonOffset": 244,
+                                                            "timeOffset": 5040
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "psid": -1,
+                    "source": "MessageReceiver",
+                    "sourceId": 37,
+                    "subType": "BSM",
+                    "timestamp": 1773256928786,
+                    "type": "J2735"
+                }
+            }
+            """;
+
+        when(pipelineLineBuilder.build(any(LineRecordContext.class)))
+            .thenAnswer(invocation -> {
+                LineRecordContext ctx = invocation.getArgument(0);
+
+                // Metadata / tags
+                assertEquals("IntegrationTest2", ctx.getMeasurement());
+                assertEquals("Unit001", ctx.getTags().get("unitId"));
+                assertEquals("192.168.55.73", ctx.getTags().get("rsuIp"));
+                assertEquals("J2735_BSM_MessageReceiver", ctx.getTags().get("topicName"));
+                assertEquals("161", ctx.getTags().get("port"));
+                assertEquals(1773256928799L, ctx.getTimestamp());
+
+                Map<String, Object> f = ctx.getFields();
+
+                // Top-level payload scalars
+                assertEquals("-1", f.get("payload.channel"));
+                assertEquals("asn.1-uper/hexstring", f.get("payload.encoding"));
+                assertEquals("BSM", f.get("payload.subType"));
+                assertEquals("J2735", f.get("payload.type"));
+
+                // BSM coreData
+                String core = "payload.payload.value.BasicSafetyMessage.coreData";
+                assertEquals("33", f.get(core + ".msgCnt"));
+                assertEquals("2DC05B91", f.get(core + ".id"));
+                assertEquals("389563900", f.get(core + ".lat"));
+                assertEquals("-771504776", f.get(core + ".long"));
+                assertEquals("27488", f.get(core + ".heading"));
+                assertEquals("2", f.get(core + ".speed"));
+                assertEquals("unavailable", f.get(core + ".transmission"));
+                assertEquals("8", f.get(core + ".accelSet.long"));
+                assertEquals("2001", f.get(core + ".accelSet.lat"));
+                assertEquals("80", f.get(core + ".brakes.wheelBrakes"));
+                assertEquals("unavailable", f.get(core + ".brakes.abs"));
+                assertEquals("0", f.get(core + ".size.width"));
+
+                // partII array uses dot notation (not brackets)
+                String partII0 = "payload.payload.value.BasicSafetyMessage.partII.0";
+                assertTrue(f.containsKey(partII0 + ".partII-Id"));
+                assertEquals("0", f.get(partII0 + ".partII-Id"));
+
+                // pathHistory crumbData array – also dot notation
+                String crumb = partII0 + ".partII-Value.VehicleSafetyExtensions.pathHistory.crumbData";
+                assertEquals("-27", f.get(crumb + ".0.elevationOffset"));
+                assertEquals("-143", f.get(crumb + ".0.latOffset"));
+                assertEquals("220", f.get(crumb + ".0.lonOffset"));
+                assertEquals("1150", f.get(crumb + ".0.timeOffset"));
+                assertEquals("-48", f.get(crumb + ".1.elevationOffset"));
+                assertEquals("5040", f.get(crumb + ".1.timeOffset"));
+
+                // pathPrediction
+                String pred = partII0 + ".partII-Value.VehicleSafetyExtensions.pathPrediction";
+                assertEquals("32767", f.get(pred + ".radiusOfCurve"));
+                assertEquals("200", f.get(pred + ".confidence"));
+
+                // No field key should contain '[' or ']'
+                for (String key : f.keySet()) {
+                    assertTrue(!key.contains("[") && !key.contains("]"),
+                            "Field key must not contain brackets: " + key);
+                }
+
+                return "bsm_line";
+            });
+
+        // When
+        String result = influxLineBuilder.buildLine(json);
+
+        // Then
+        assertEquals("bsm_line", result);
         verify(pipelineLineBuilder, times(1)).build(any(LineRecordContext.class));
     }
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Fix the issue with influxDB parsing for line protocol failed
<!--- Describe your changes in detail -->
`2026-03-11 19:22:08.800 INFO  [unit.Unit001.stream.rsu.192_168_55_73.>-unit_Unit001_stream_rsu_192_168_55_73_g_queue_fcf50475-0] c.t.t.d.d.DataIngestionDepositor - Built Influx line: IntegrationTest2,unitId=Unit001,rsuIp=192.168.55.73,topicName=J2735_BSM_MessageReceiver,port=161 payload.channel=-1i,payload.encoding="asn.1-uper/hexstring",payload.flags=0i,payload.payload.messageId=20i,payload.payload.value.BasicSafetyMessage.coreData.accelSet.lat=2001i,payload.payload.value.BasicSafetyMessage.coreData.accelSet.long=8i,payload.payload.value.BasicSafetyMessage.coreData.accelSet.vert=-127i,payload.payload.value.BasicSafetyMessage.coreData.accelSet.yaw=0i,payload.payload.value.BasicSafetyMessage.coreData.accuracy.orientation=0i,payload.payload.value.BasicSafetyMessage.coreData.accuracy.semiMajor=11i,payload.payload.value.BasicSafetyMessage.coreData.accuracy.semiMinor=11i,payload.payload.value.BasicSafetyMessage.coreData.angle=127i,payload.payload.value.BasicSafetyMessage.coreData.brakes.abs="unavailable",payload.payload.value.BasicSafetyMessage.coreData.brakes.auxBrakes="unavailable",payload.payload.value.BasicSafetyMessage.coreData.brakes.brakeBoost="unavailable",payload.payload.value.BasicSafetyMessage.coreData.brakes.scs="unavailable",payload.payload.value.BasicSafetyMessage.coreData.brakes.traction="unavailable",payload.payload.value.BasicSafetyMessage.coreData.brakes.wheelBrakes=80i,payload.payload.value.BasicSafetyMessage.coreData.elev=305i,payload.payload.value.BasicSafetyMessage.coreData.heading=27488i,payload.payload.value.BasicSafetyMessage.coreData.id="2DC05B91",payload.payload.value.BasicSafetyMessage.coreData.lat=389563900i,payload.payload.value.BasicSafetyMessage.coreData.long=-771504776i,payload.payload.value.BasicSafetyMessage.coreData.msgCnt=33i,payload.payload.value.BasicSafetyMessage.coreData.secMark=8599i,payload.payload.value.BasicSafetyMessage.coreData.size.length=0i,payload.payload.value.BasicSafetyMessage.coreData.size.width=0i,payload.payload.value.BasicSafetyMessage.coreData.speed=2i,payload.payload.value.BasicSafetyMessage.coreData.transmission="unavailable",payload.payload.value.BasicSafetyMessage.partII[0].partII-Id=0i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[0].elevationOffset=-27i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[0].latOffset=-143i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[0].lonOffset=220i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[0].timeOffset=1150i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[1].elevationOffset=-48i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[1].latOffset=-200i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[1].lonOffset=244i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[1].timeOffset=5040i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[2].elevationOffset=-22i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[2].latOffset=-167i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[2].lonOffset=297i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[2].timeOffset=12700i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[3].elevationOffset=-120i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[3].latOffset=1i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[3].lonOffset=331i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[3].timeOffset=15810i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[4].elevationOffset=-104i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[4].latOffset=-5i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[4].lonOffset=390i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[4].timeOffset=17590i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[5].elevationOffset=-64i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[5].latOffset=136i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[5].lonOffset=460i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[5].timeOffset=20410i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[6].elevationOffset=-65i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[6].latOffset=-29i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[6].lonOffset=112i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[6].timeOffset=23880i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[7].elevationOffset=-65i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[7].latOffset=-183i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[7].lonOffset=70i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[7].timeOffset=26540i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[8].elevationOffset=-110i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[8].latOffset=-271i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[8].lonOffset=-50i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[8].timeOffset=28140i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[9].elevationOffset=-196i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[9].latOffset=-259i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[9].lonOffset=-31i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[9].timeOffset=30740i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[10].elevationOffset=-232i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[10].latOffset=-360i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[10].lonOffset=119i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[10].timeOffset=33690i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[11].elevationOffset=-237i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[11].latOffset=-290i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[11].lonOffset=301i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[11].timeOffset=37300i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[12].elevationOffset=-204i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[12].latOffset=-172i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[12].lonOffset=118i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[12].timeOffset=41300i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[13].elevationOffset=-148i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[13].latOffset=-220i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[13].lonOffset=292i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[13].timeOffset=45820i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[14].elevationOffset=-134i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[14].latOffset=-249i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[14].lonOffset=231i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathHistory.crumbData[14].timeOffset=52850i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathPrediction.confidence=200i,payload.payload.value.BasicSafetyMessage.partII[0].partII-Value.VehicleSafetyExtensions.pathPrediction.radiusOfCurve=32767i,payload.psid=-1i,payload.source="MessageReceiver",payload.sourceId=37i,payload.subType="BSM",payload.timestamp=1773256928786i,payload.type="J2735" 1773256928799 (bytes: 10250)
2026-03-11 19:22:08.800 ERROR [influx-batch-writer-cd2685ff] c.t.t.d.d.DataIngestionDepositor - Batch write error: Error writing batch to InfluxDB3: HTTP status code: 400; Message: write buffer error: parsing for line protocol failed
java.lang.RuntimeException: Error writing batch to InfluxDB3: HTTP status code: 400; Message: write buffer error: parsing for line protocol failed
    at com.telematic.telematic_rsu_management_service.repository.influx.InfluxDBRepository.writeBatch(InfluxDBRepository.java:72) ~[!/:0.0.1-SNAPSHOT]
    at com.telematic.telematic_rsu_management_service.data_ingestion.depositor.DataIngestionDepositor.writerLoop(DataIngestionDepositor.java:108) ~[!/:0.0.1-SNAPSHOT]
    at java.base/java.lang.Thread.run(Unknown Source) [?:?]
Caused by: com.influxdb.v3.client.InfluxDBApiHttpException: HTTP status code: 400; Message: write buffer error: parsing for line protocol failed
    at com.influxdb.v3.client.internal.RestClient.request(RestClient.java:254) ~[influxdb3-java-1.7.0.jar!/:1.7.0]
    at com.influxdb.v3.client.internal.InfluxDBClientImpl.writeData(InfluxDBClientImpl.java:367) ~[influxdb3-java-1.7.0.jar!/:1.7.0]
    at com.influxdb.v3.client.internal.InfluxDBClientImpl.writeRecords(InfluxDBClientImpl.java:141) ~[influxdb3-java-1.7.0.jar!/:1.7.0]
    at com.influxdb.v3.client.internal.InfluxDBClientImpl.writeRecord(InfluxDBClientImpl.java:131) ~[influxdb3-java-1.7.0.jar!/:1.7.0]
    at com.telematic.telematic_rsu_management_service.repository.influx.InfluxDBRepository.writeBatch(InfluxDBRepository.java:70) ~[!/:0.0.1-SNAPSHOT]
    ... 2 more
2026-03-11 19:22:08.801 INFO  [unit.Unit001.stream.rsu.192_168_55_74.>-unit_Unit001_stream_rsu_192_168_55_74_g_queue_cce77c5e-3] c.t.t.d.d.DataIngestionDepositor - Built Influx line: IntegrationTest2,unitId=Unit001,rsuIp=192.168.55.74,topicName=J2735_BSM_MessageReceiver,port=161 payload.channel=-1i,payload.encoding="asn.1-uper/hexstring",payload.flags=0i,payload.payload.messageId=20i,payload.payload.value.BasicSafetyMessage.coreData.accelSet.lat=2001i,payload.payload.value.BasicSafetyMessage.coreData.accelSet.long=8i,payload.payload.value.BasicSafetyMessage.coreData.accelSet.vert=-127i,payload.payload.value.BasicSafetyMessage....`
## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
NA
<!-- e.g. CAR-123 -->

## Motivation and Context
NA
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
