### PR TITLE
setting retention with default value

### DIFF
--- a/telematic_system/telematic.local.env
+++ b/telematic_system/telematic.local.env
@@ -7,7 +7,7 @@ DOCKER_INFLUXDB_INIT_PASSWORD=P@ssword1 #Required: Create a credential password 
 DOCKER_INFLUXDB_INIT_BUCKET=infrastructure-dev #Required: Create an bucket on container initial startup. You can create more buckets inside the influxDB container.
 DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=my-super-secret-auth-token #Required: Manually set the token value
 DOCKER_INFLUXDB_INIT_ORG=my-org #Required: Create an organization on container startup. You can create more orgs inside the same influxDB container.
-DOCKER_INFLUXDB_INIT_RETENTION= #Optional: If not set, the initial bucket will retain data for one year.
+DOCKER_INFLUXDB_INIT_RETENTION=0 #Optional: If not set, the initial bucket will retain data for one year.
 INFLUX_URL=127.0.0.1:8086
 
 ###################################################

--- a/telematic_system/telematic.local.env
+++ b/telematic_system/telematic.local.env
@@ -7,7 +7,7 @@ DOCKER_INFLUXDB_INIT_PASSWORD=P@ssword1 #Required: Create a credential password 
 DOCKER_INFLUXDB_INIT_BUCKET=infrastructure-dev #Required: Create an bucket on container initial startup. You can create more buckets inside the influxDB container.
 DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=my-super-secret-auth-token #Required: Manually set the token value
 DOCKER_INFLUXDB_INIT_ORG=my-org #Required: Create an organization on container startup. You can create more orgs inside the same influxDB container.
-DOCKER_INFLUXDB_INIT_RETENTION=0 #Optional: If not set, the initial bucket will retain data for one year.
+DOCKER_INFLUXDB_INIT_RETENTION=0 
 INFLUX_URL=127.0.0.1:8086
 
 ###################################################


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR updates the local env file to set the influxDB retention variable with default of 0.
<!--- Describe your changes in detail -->

## Related GitHub Issue
N/A
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
N/A
<!-- e.g. CAR-123 -->

## Motivation and Context
When deploying the Telematics tool there was an error when not setting the influxDB retention variable.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Local deployment
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
